### PR TITLE
fix: Disable `Refresh` Button During Bookmark Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ sudo just install
 
 Potential improvements:
 
-- [UI] Populate menu bar with more actions.
 - [UI] Detailed `About` page.
 - [Performance] Check performance with multiple remote + local instances.
 - [Performance] Check performance with high amount of bookmarks spread across multiple instances.

--- a/src/app.rs
+++ b/src/app.rs
@@ -73,19 +73,19 @@ pub enum Message {
     CompleteRemoveDialog(Account, Option<Bookmark>),
     DialogCancel,
     DialogUpdate(DialogPage),
+    DoneRefreshBookmarksForAccount(Account, Vec<Bookmark>),
+    DoneRefreshBookmarksForAllAccounts(Vec<Bookmark>),
     EditAccount(Account),
     EditBookmark(Account, Bookmark),
-    LoadAccounts,
+    EmpptyMessage,
     Key(Modifiers, Key),
+    LoadAccounts,
+    LoadBookmarks,
     Modifiers(Modifiers),
     OpenAccountsPage,
     OpenExternalUrl(String),
     OpenRemoveAccountDialog(Account),
     OpenRemoveBookmarkDialog(Account, Bookmark),
-    StartRefreshBookmarksForAllAccounts,
-    DoneRefreshBookmarksForAllAccounts(Vec<Bookmark>),
-    DoneRefreshBookmarksForAccount(Account, Vec<Bookmark>),
-    StartRefreshBookmarksForAccount(Account),
     RemoveAccount(Account),
     RemoveBookmark(Account, Bookmark),
     SearchBookmarks(String),
@@ -101,14 +101,15 @@ pub enum Message {
     SetBookmarkTitle(String),
     SetBookmarkURL(String),
     SetBookmarkUnread(bool),
+    StartRefreshBookmarksForAccount(Account),
+    StartRefreshBookmarksForAllAccounts,
+    StartupCompleted,
     SystemThemeModeChange,
     ToggleContextPage(ContextPage),
     UpdateAccount(Account),
     UpdateBookmark(Account, Bookmark),
     UpdateConfig(Config),
     ViewBookmarkNotes(Bookmark),
-    StartupCompleted,
-    LoadBookmarks,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -188,7 +189,10 @@ impl Application for Cosmicding {
     }
 
     fn header_start(&self) -> Vec<Element<Self::Message>> {
-        vec![crate::menu::menu_bar(&self.key_binds)]
+        vec![crate::menu::menu_bar(
+            &self.key_binds,
+            !self.accounts_view.accounts.is_empty(),
+        )]
     }
 
     fn nav_model(&self) -> Option<&nav_bar::Model> {
@@ -855,6 +859,9 @@ impl Application for Cosmicding {
                     |msg| cosmic::app::Message::App(msg),
                 ))
             }
+            Message::EmpptyMessage => {
+                commands.push(Command::none());
+            }
         }
         Command::batch(commands)
     }
@@ -969,6 +976,7 @@ impl ContextPage {
 pub enum MenuAction {
     About,
     AddAccount,
+    AddBookmark,
     Settings,
 }
 
@@ -980,6 +988,7 @@ impl _MenuAction for MenuAction {
             MenuAction::About => Message::ToggleContextPage(ContextPage::About),
             MenuAction::AddAccount => Message::AddAccount,
             MenuAction::Settings => Message::ToggleContextPage(ContextPage::Settings),
+            MenuAction::AddBookmark => Message::AddBookmarkForm,
         }
     }
 }

--- a/src/key_binds.rs
+++ b/src/key_binds.rs
@@ -23,6 +23,8 @@ pub fn key_binds() -> HashMap<KeyBind, MenuAction> {
 
     bind!([Ctrl], Key::Character(",".into()), Settings);
     bind!([Ctrl], Key::Character("i".into()), About);
+    bind!([Ctrl, Shift], Key::Character("n".into()), AddAccount);
+    bind!([Ctrl], Key::Character("n".into()), AddBookmark);
 
     key_binds
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -11,13 +11,23 @@ use crate::{
     fl,
 };
 
-pub fn menu_bar<'a>(key_binds: &HashMap<KeyBind, MenuAction>) -> Element<'a, Message> {
+pub fn menu_bar<'a>(
+    key_binds: &HashMap<KeyBind, MenuAction>,
+    accounts_enabled: bool,
+) -> Element<'a, Message> {
     MenuBar::new(vec![
         Tree::with_children(
             root(fl!("file")),
             items(
                 key_binds,
-                vec![Item::Button(fl!("add-account"), MenuAction::AddAccount)],
+                vec![
+                    Item::Button(fl!("add-account"), MenuAction::AddAccount),
+                    if accounts_enabled {
+                        Item::Button(fl!("add-bookmark"), MenuAction::AddBookmark)
+                    } else {
+                        Item::ButtonDisabled(fl!("add-bookmark"), MenuAction::AddBookmark)
+                    },
+                ],
             ),
         ),
         Tree::with_children(

--- a/src/pages/bookmarks.rs
+++ b/src/pages/bookmarks.rs
@@ -33,6 +33,7 @@ pub enum BookmarksMessage {
     RefreshBookmarks,
     SearchBookmarks(String),
     ViewNotes(Bookmark),
+    EmptyMessage,
 }
 
 impl Default for BookmarksView {
@@ -204,8 +205,16 @@ impl BookmarksView {
                     )
                     .push(
                         widget::button::text(fl!("refresh"))
-                            .on_press(BookmarksMessage::RefreshBookmarks)
-                            .style(theme::Button::Standard),
+                            .on_press(if !self.query_placeholder.is_empty() {
+                                BookmarksMessage::EmptyMessage
+                            } else {
+                                BookmarksMessage::RefreshBookmarks
+                            })
+                            .style(if !self.query_placeholder.is_empty() {
+                                theme::Button::MenuItem
+                            } else {
+                                theme::Button::Standard
+                            }),
                     )
                     .push(
                         widget::button::text(fl!("add-bookmark"))
@@ -265,6 +274,9 @@ impl BookmarksView {
                 commands.push(Command::perform(async {}, |_| {
                     Message::ViewBookmarkNotes(bookmark)
                 }));
+            }
+            BookmarksMessage::EmptyMessage => {
+                commands.push(Command::perform(async {}, |_| Message::EmpptyMessage));
             }
         }
         Command::batch(commands)


### PR DESCRIPTION
Disabling `Refresh` button during search, resolves #5.

Updating menu items.
