### PR TITLE
fix: Populate Application Title On Startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,6 +2656,7 @@ dependencies = [
  "bytes",
  "dnd",
  "glam",
+ "iced_accessibility",
  "log",
  "mime 0.1.0",
  "num-traits",
@@ -2737,6 +2738,7 @@ source = "git+https://github.com/pop-os/libcosmic?rev=953685a88267894ea3fa40f2b9
 dependencies = [
  "bytes",
  "dnd",
+ "iced_accessibility",
  "iced_core",
  "iced_futures",
  "raw-window-handle",
@@ -2797,6 +2799,7 @@ version = "0.14.0-dev"
 source = "git+https://github.com/pop-os/libcosmic?rev=953685a88267894ea3fa40f2b99139c3c4e784d6#953685a88267894ea3fa40f2b99139c3c4e784d6"
 dependencies = [
  "dnd",
+ "iced_accessibility",
  "iced_renderer",
  "iced_runtime",
  "num-traits",
@@ -2814,6 +2817,7 @@ version = "0.14.0-dev"
 source = "git+https://github.com/pop-os/libcosmic?rev=953685a88267894ea3fa40f2b99139c3c4e784d6#953685a88267894ea3fa40f2b99139c3c4e784d6"
 dependencies = [
  "dnd",
+ "iced_accessibility",
  "iced_futures",
  "iced_graphics",
  "iced_runtime",
@@ -3302,6 +3306,7 @@ dependencies = [
  "fraction",
  "freedesktop-icons",
  "iced",
+ "iced_accessibility",
  "iced_core",
  "iced_futures",
  "iced_renderer",
@@ -3313,6 +3318,7 @@ dependencies = [
  "lazy_static",
  "palette",
  "rfd",
+ "ron",
  "serde",
  "slotmap",
  "taffy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,18 @@ features = ["fluent-system", "desktop-requester"]
 [dependencies.libcosmic]
 git = "https://github.com/pop-os/libcosmic"
 default-features = false
-features = ["dbus-config", "tokio", "winit", "wgpu"]
+# features = ["dbus-config", "tokio", "winit", "wgpu"]
+features = [
+    "a11y",
+    "dbus-config",
+    # NOTE: (vkhitrin) this is a temporary workaround to set initial
+    #       application title.
+    "multi-window",
+    "single-instance",
+    "tokio",
+    "winit",
+    "wgpu",
+]
 rev = "953685a88267894ea3fa40f2b99139c3c4e784d6"
 version = "0.1.0"
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,6 @@ sudo just install
 
 ## Roadmap
 
-### Known isuses
-
-- [Application] After updating to [libcosmic#953685a88267894ea3fa40f2b99139c3c4e784d6](https://github.com/pop-os/libcosmic/tree/953685a88267894ea3fa40f2b99139c3c4e784d6),
-  application title is not updated until navigrating manually to a page.
-
 ### Future
 
 Potential improvements:

--- a/src/app.rs
+++ b/src/app.rs
@@ -1028,14 +1028,16 @@ impl Cosmicding {
         cosmic::app::command::set_theme(theme)
     }
 
-    // FIXME: (vkhitrin) title is not set on application startup
-    //                   it is updated when navigating between pages.
     pub fn update_title(&mut self) -> Task<Message> {
         let window_title = match self.nav.text(self.nav.active()) {
             Some(page) => format!("{page} — {}", fl!("cosmicding")),
             _ => fl!("cosmicding"),
         };
-        self.set_window_title(window_title)
+        if let Some(id) = self.core.main_window_id() {
+            self.set_window_title(window_title, id)
+        } else {
+            Task::none()
+        }
     }
 }
 


### PR DESCRIPTION
Enabling `multi-window` feature in `libcosmic`.
Builtin function `set_window_title` correctly sets application title on
startup.

This may be a temporary workaround. cosmicding may not benefit from
mutli winodw capability.

Resolves #10.
