### PR TITLE
fix: Prevent Duplicate Accounts

### DIFF
--- a/i18n/en/cosmicding.ftl
+++ b/i18n/en/cosmicding.ftl
@@ -1,5 +1,6 @@
 about = About
 account = Account
+account-exists =Account already exists
 accounts = Accounts
 accounts-with-count = Accounts ({$count})
 add-account = Add Account

--- a/i18n/sv/cosmicding.ftl
+++ b/i18n/sv/cosmicding.ftl
@@ -1,5 +1,6 @@
 about = Om
 account = Konto
+account-exists = Konto finns redan
 accounts = Konton
 accounts-with-count = Konton ({$count})
 add-account = Lägg till konto

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -445,4 +445,15 @@ impl SqliteDatabase {
             .unwrap();
         result
     }
+    pub async fn check_if_account_exists(&mut self, url: &String, api_token: &String) -> bool {
+        let query: &str =
+            "SELECT COUNT(*) FROM UserAccounts WHERE instance = $1 AND api_token = $2;";
+        let result: bool = sqlx::query_scalar(query)
+            .bind(url)
+            .bind(api_token)
+            .fetch_one(&self.conn)
+            .await
+            .unwrap();
+        result
+    }
 }


### PR DESCRIPTION
Perform a check in the database before adding an account, to ensure that
no duplicate occur.

Resolves #55.
