### PR TITLE
feat: Add Shared Bookmarks

### DIFF
--- a/i18n/en/cosmicding.ftl
+++ b/i18n/en/cosmicding.ftl
@@ -65,6 +65,7 @@ save = Save
 search = Search
 setting-managed-externally = This setting can only be managed from Linkding web UI
 settings = Settings
+sharing = Sharing
 shared = Shared
 shared-disabled = Shared (Disabled)
 snapshot = Snapshot

--- a/i18n/sv/cosmicding.ftl
+++ b/i18n/sv/cosmicding.ftl
@@ -65,6 +65,7 @@ save = Spara
 search = Sök
 setting-managed-externally = Den här inställningen kan endast hanteras från Linkding webbgränssnitt
 settings = Inställningar
+sharing = Delning
 shared = Delad
 shared-disabled = Delad (Inaktiverad)
 snapshot = Ögonblicksbild

--- a/migrations/20250301214058_Shared_Bookmarks_Workaround.sql
+++ b/migrations/20250301214058_Shared_Bookmarks_Workaround.sql
@@ -1,0 +1,2 @@
+-- Workaround due to linkding not exposing the bookmark owner account via the API
+ALTER TABLE Bookmarks ADD COLUMN is_owner INTEGER DEFAULT 1;

--- a/src/app/nav.rs
+++ b/src/app/nav.rs
@@ -38,7 +38,11 @@ impl AppNavPage {
                 .map(app::Message::AccountsView),
             AppNavPage::BookmarksView => app
                 .bookmarks_view
-                .view(app.state, &app.bookmarks_cursor)
+                .view(
+                    app.state,
+                    &app.bookmarks_cursor,
+                    app.accounts_cursor.total_entries == 0,
+                )
                 .map(app::Message::BookmarksView),
         }
     }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -203,8 +203,9 @@ impl SqliteDatabase {
                 date_added,
                 date_modified,
                 website_title,
-                website_description)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17);";
+                website_description,
+                is_owner)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18);";
         sqlx::query(query)
             .bind(bookmark.user_account_id)
             .bind(bookmark.linkding_internal_id)
@@ -223,6 +224,7 @@ impl SqliteDatabase {
             .bind(&bookmark.date_modified)
             .bind(&bookmark.website_title)
             .bind(&bookmark.website_description)
+            .bind(&bookmark.is_owner)
             .execute(&self.conn)
             .await
             .unwrap();
@@ -288,6 +290,7 @@ impl SqliteDatabase {
                     date_modified: row.get("date_modified"),
                     website_title: row.get("website_title"),
                     website_description: row.get("website_description"),
+                    is_owner: row.get("is_owner"),
                 }
             })
             .collect();
@@ -311,7 +314,7 @@ impl SqliteDatabase {
                 date_modified=$13,
                 website_title=$14,
                 website_description=$15
-            WHERE linkding_internal_id=$16;";
+            WHERE id=$16;";
         sqlx::query(query)
             .bind(&new_bookmark.url)
             .bind(&new_bookmark.title)
@@ -328,7 +331,7 @@ impl SqliteDatabase {
             .bind(&new_bookmark.date_modified)
             .bind(&new_bookmark.website_title)
             .bind(&new_bookmark.website_description)
-            .bind(old_bookmark.linkding_internal_id)
+            .bind(old_bookmark.id)
             .execute(&self.conn)
             .await
             .unwrap();
@@ -430,6 +433,7 @@ impl SqliteDatabase {
                     date_modified: row.get("date_modified"),
                     website_title: row.get("website_title"),
                     website_description: row.get("website_description"),
+                    is_owner: row.get("is_owner"),
                 }
             })
             .collect();

--- a/src/models/bookmarks.rs
+++ b/src/models/bookmarks.rs
@@ -21,8 +21,11 @@ pub struct Bookmark {
     pub tag_names: Vec<String>,
     pub date_added: Option<String>,
     pub date_modified: Option<String>,
+    pub is_owner: Option<bool>,
 }
 
+// NOTE: (vkhitrin) as of March 1st, 2025, linkding doesn't expose the user which shared the
+// bookmark, we will maintain an internal field to indicate if the current account is an owner.
 impl Bookmark {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -43,6 +46,7 @@ impl Bookmark {
         linkding_tag_names: Vec<String>,
         linkding_date_added: Option<String>,
         linkding_date_modified: Option<String>,
+        internnal_workaround_is_owner: Option<bool>,
     ) -> Self {
         Self {
             id: None,
@@ -63,6 +67,7 @@ impl Bookmark {
             tag_names: linkding_tag_names,
             date_added: linkding_date_added,
             date_modified: linkding_date_modified,
+            is_owner: internnal_workaround_is_owner,
         }
     }
 }


### PR DESCRIPTION
Allows accounts to fetch shared bookmarks which are shared by other
users (accounts) in the instance.

Fix an issue when removing tags from bookmarks during edit.

Fix bookmarks page view to display content based on the presence of
accounts, and bookmarks.

Resolves #67.
