### PR TITLE
refactor: Do Not Block UI Threads On HTTP Calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,14 +372,15 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand 2.3.0",
  "futures-lite 2.6.0",
+ "pin-project-lite",
  "slab",
 ]
 
@@ -497,7 +498,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -532,7 +533,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -617,7 +618,7 @@ dependencies = [
  "derive_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -743,9 +744,9 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -758,7 +759,7 @@ checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -842,9 +843,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1070,7 +1071,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#e5802b535bf9d6599b0ac90a9499e80c60c0284b"
+source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1092,7 +1093,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#e5802b535bf9d6599b0ac90a9499e80c60c0284b"
+source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1158,7 +1159,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#e5802b535bf9d6599b0ac90a9499e80c60c0284b"
+source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -1326,7 +1327,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1337,7 +1338,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1386,7 +1387,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1397,7 +1398,7 @@ checksum = "ccfae181bab5ab6c5478b2ccb69e4c68a02f8c3ec72f6616bfec9dbc599d2ee0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1477,7 +1478,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1608,7 +1609,7 @@ checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1950,7 +1951,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1976,9 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "freedesktop-desktop-entry"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2258b98a780699da05c858682498ceaf3942013d7d93ca7584e26fbacc58f2d9"
+checksum = "cbcb2951884fd80c5b3093ce762bebcc4ec351fadff3c253f9d09cb91917ddd2"
 dependencies = [
  "gettext-rs",
  "log",
@@ -2093,7 +2094,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2342,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2613,7 +2614,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.100",
+ "syn 2.0.101",
  "unic-langid",
 ]
 
@@ -2627,7 +2628,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2657,7 +2658,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e5802b535bf9d6599b0ac90a9499e80c60c0284b"
+source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2675,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#e5802b535bf9d6599b0ac90a9499e80c60c0284b"
+source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -2684,7 +2685,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e5802b535bf9d6599b0ac90a9499e80c60c0284b"
+source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
 dependencies = [
  "bitflags 2.9.0",
  "bytes",
@@ -2709,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e5802b535bf9d6599b0ac90a9499e80c60c0284b"
+source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
 dependencies = [
  "futures",
  "iced_core",
@@ -2735,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e5802b535bf9d6599b0ac90a9499e80c60c0284b"
+source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
 dependencies = [
  "bitflags 2.9.0",
  "bytemuck",
@@ -2757,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e5802b535bf9d6599b0ac90a9499e80c60c0284b"
+source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2769,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e5802b535bf9d6599b0ac90a9499e80c60c0284b"
+source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
 dependencies = [
  "bytes",
  "cosmic-client-toolkit",
@@ -2785,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e5802b535bf9d6599b0ac90a9499e80c60c0284b"
+source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2801,7 +2802,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e5802b535bf9d6599b0ac90a9499e80c60c0284b"
+source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.9.0",
@@ -2832,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e5802b535bf9d6599b0ac90a9499e80c60c0284b"
+source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -2851,7 +2852,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e5802b535bf9d6599b0ac90a9499e80c60c0284b"
+source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -2993,7 +2994,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3218,7 +3219,7 @@ checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3336,9 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89234b2cc610a7dd927ebde6b41dd1a5d4214cffaef4cf1fb2195d592f92518f"
+checksum = "1077d333efea6170d9ccb96d3c3026f300ca0773da4938cc4c811daa6df68b0c"
 dependencies = [
  "arrayvec",
  "smallvec",
@@ -3362,7 +3363,7 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#e5802b535bf9d6599b0ac90a9499e80c60c0284b"
+source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
 dependencies = [
  "apply",
  "ashpd 0.9.2",
@@ -3906,7 +3907,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4199,7 +4200,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4266,7 +4267,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4300,7 +4301,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4414,7 +4415,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4449,7 +4450,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4579,7 +4580,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -4614,7 +4615,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "toml_edit 0.22.24",
+ "toml_edit 0.22.26",
 ]
 
 [[package]]
@@ -4636,7 +4637,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4656,7 +4657,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "version_check",
  "yansi",
 ]
@@ -4669,9 +4670,9 @@ checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.4"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
 ]
@@ -5007,7 +5008,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.100",
+ "syn 2.0.101",
  "walkdir",
 ]
 
@@ -5245,7 +5246,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5269,7 +5270,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5297,9 +5298,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -5573,7 +5574,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5596,7 +5597,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.100",
+ "syn 2.0.101",
  "tempfile",
  "tokio",
  "url",
@@ -5764,7 +5765,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
- "kurbo 0.11.1",
+ "kurbo 0.11.2",
  "siphasher",
 ]
 
@@ -5792,9 +5793,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5812,13 +5813,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5916,7 +5917,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5927,7 +5928,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6054,7 +6055,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6112,9 +6113,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 
 [[package]]
 name = "toml_edit"
@@ -6129,9 +6130,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -6185,7 +6186,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6379,7 +6380,7 @@ dependencies = [
  "flate2",
  "fontdb 0.18.0",
  "imagesize",
- "kurbo 0.11.1",
+ "kurbo 0.11.2",
  "log",
  "pico-args",
  "roxmltree",
@@ -6505,7 +6506,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -6540,7 +6541,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6571,9 +6572,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7208998eaa3870dad37ec8836979581506e0c5c64c20c9e79e9d2a10d6f47bf"
+checksum = "fe770181423e5fc79d3e2a7f4410b7799d5aab1de4372853de3c6aa13ca24121"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -6585,9 +6586,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.8"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2120de3d33638aaef5b9f4472bff75f07c56379cf76ea320bd3a3d65ecaf73f"
+checksum = "978fa7c67b0847dbd6a9f350ca2569174974cd4082737054dbb7fbb79d7d9a61"
 dependencies = [
  "bitflags 2.9.0",
  "rustix 0.38.44",
@@ -6608,9 +6609,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.8"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93029cbb6650748881a00e4922b076092a6a08c11e7fbdb923f064b23968c5d"
+checksum = "a65317158dec28d00416cb16705934070aef4f8393353d41126c54264ae0f182"
 dependencies = [
  "rustix 0.38.44",
  "wayland-client",
@@ -6619,9 +6620,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.6"
+version = "0.32.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0781cf46869b37e36928f7b432273c0995aa8aed9552c556fb18754420541efc"
+checksum = "779075454e1e9a521794fed15886323ea0feda3f8b0fc1390f5398141310422a"
 dependencies = [
  "bitflags 2.9.0",
  "wayland-backend",
@@ -6632,9 +6633,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccaacc76703fefd6763022ac565b590fcade92202492381c95b2edfdf7d46b3"
+checksum = "4fd38cdad69b56ace413c6bcc1fbf5acc5e2ef4af9d5f8f1f9570c0c83eae175"
 dependencies = [
  "bitflags 2.9.0",
  "wayland-backend",
@@ -6645,9 +6646,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248a02e6f595aad796561fa82d25601bd2c8c3b145b1c7453fc8f94c1a58f8b2"
+checksum = "1cb6cdc73399c0e06504c437fe3cf886f25568dd5454473d565085b36d6a8bbf"
 dependencies = [
  "bitflags 2.9.0",
  "wayland-backend",
@@ -6670,9 +6671,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-server"
-version = "0.31.7"
+version = "0.31.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fabd7ed68cff8e7657b8a8a1fbe90cb4a3f0c30d90da4bf179a7a23008a4cb"
+checksum = "485dfb8ccf0daa0d34625d34e6ac15f99e550a7999b6fd88a0835ccd37655785"
 dependencies = [
  "bitflags 2.9.0",
  "downcast-rs",
@@ -6949,7 +6950,7 @@ checksum = "942ac266be9249c84ca862f0a164a39533dc2f6f33dc98ec89c8da99b82ea0bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6960,7 +6961,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6971,7 +6972,7 @@ checksum = "da33557140a288fae4e1d5f8873aaf9eb6613a9cf82c3e070223ff177f598b60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6982,7 +6983,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7537,7 +7538,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -7639,7 +7640,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "zvariant_utils 2.1.0",
 ]
 
@@ -7682,11 +7683,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -7697,18 +7698,18 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7728,7 +7729,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -7757,7 +7758,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7825,7 +7826,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "zvariant_utils 2.1.0",
 ]
 
@@ -7848,5 +7849,5 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]

--- a/i18n/en/cosmicding.ftl
+++ b/i18n/en/cosmicding.ftl
@@ -1,6 +1,6 @@
 about = About
 account = Account
-account-exists =Account already exists
+account-exists = Account already exists
 accounts = Accounts
 accounts-with-count = Accounts ({$count})
 actions = Actions
@@ -34,6 +34,7 @@ enabled = Enabled
 enabled-public-sharing = Public bookmarks sharing enabled
 enabled-sharing = Bookmarks sharing enabled
 failed = failed
+failed-to-add-account = Failed to add account {$acc}: {$err}
 failed-refreshing-accounts = Failed refreshing some accounts ({$accounts})
 failed-refreshing-bookmarks-for-account = Failed refreshing account {$account}
 failed-to-find-linkding-api-endpoint = Failed to find linkding API endpoint

--- a/i18n/sv/cosmicding.ftl
+++ b/i18n/sv/cosmicding.ftl
@@ -36,6 +36,7 @@ enabled-sharing = Bokmärkesdelning har aktiverats
 failed = misslyckades
 failed-refreshing-accounts = Misslyckades att uppdatera vissa konton ({$accounts})
 failed-refreshing-bookmarks-for-account = Misslyckades att uppdatera konto {$account}
+failed-to-add-account = Misslyckades med att lägga till konto {$acc}: {$err}
 failed-to-find-linkding-api-endpoint = Det gick inte att hitta linkding API-slutpunkt
 failed-to-parse-response = Misslyckades att tolka svar
 file = Fil

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1,10 +1,13 @@
-use crate::app::{
-    config::{AppTheme, CosmicConfig, SortOption},
-    context::ContextPage,
-    dialog::DialogPage,
-};
 use crate::models::account::{Account, LinkdingAccountApiResponse};
-use crate::models::bookmarks::{Bookmark, DetailedResponse};
+use crate::models::bookmarks::{Bookmark, BookmarkRemoveResponse, DetailedResponse};
+use crate::{
+    app::{
+        config::{AppTheme, CosmicConfig, SortOption},
+        context::ContextPage,
+        dialog::DialogPage,
+    },
+    models::bookmarks::BookmarkCheckDetailsResponse,
+};
 use cosmic::widget::{self};
 use cosmic::{
     iced::keyboard::{Key, Modifiers},
@@ -14,25 +17,28 @@ use cosmic::{
 #[derive(Debug, Clone)]
 pub enum ApplicationAction {
     AccountsView(AccountsAction),
-    AddAccount,
-    AddBookmark(Account, Bookmark),
+    AddAccountForm,
     AddBookmarkForm,
     AddBookmarkFormAccountIndex(usize),
     AppTheme(AppTheme),
     BookmarksView(BookmarksAction),
     CloseToast(widget::ToastId),
-    CompleteAddAccount(Account),
     CompleteRemoveDialog(Option<i64>, Option<Bookmark>),
     ContextClose,
     DecrementPageIndex(String),
     DialogCancel,
     DialogUpdate(DialogPage),
+    DoneAddAccount(Account, Option<LinkdingAccountApiResponse>),
+    DoneAddBookmark(Account, Option<BookmarkCheckDetailsResponse>),
+    DoneEditAccount(Account, Option<LinkdingAccountApiResponse>),
+    DoneEditBookmark(Account, Option<BookmarkCheckDetailsResponse>),
     DoneFetchFaviconForBookmark(String, Bytes),
     DoneRefreshAccountProfile(Account, Option<LinkdingAccountApiResponse>),
     DoneRefreshBookmarksForAccount(Account, Vec<DetailedResponse>),
     DoneRefreshBookmarksForAllAccounts(Vec<DetailedResponse>),
-    EditAccount(Account),
-    EditBookmark(i64, Bookmark),
+    DoneRemoveBookmark(Account, Bookmark, Option<BookmarkRemoveResponse>),
+    EditAccountForm(Account),
+    EditBookmarkForm(i64, Bookmark),
     Empty,
     EnableFavicons(bool),
     IncrementPageIndex(String),
@@ -49,7 +55,6 @@ pub enum ApplicationAction {
     OpenRemoveBookmarkDialog(i64, Bookmark),
     PurgeFaviconsCache,
     RemoveAccount(Account),
-    RemoveBookmark(i64, Bookmark),
     SearchBookmarks(String),
     SetAccountAPIKey(String),
     SetAccountDisplayName(String),
@@ -64,15 +69,18 @@ pub enum ApplicationAction {
     SetBookmarkUnread(bool),
     SetItemsPerPage(u8),
     SortOption(SortOption),
+    StartAddAccount(Account),
+    StartAddBookmark(Account, Bookmark),
+    StartEditAccount(Account),
+    StartEditBookmark(Account, Bookmark),
     StartFetchFaviconForBookmark(Bookmark),
     StartRefreshAccountProfile(Account),
     StartRefreshBookmarksForAccount(Account),
     StartRefreshBookmarksForAllAccounts,
+    StartRemoveBookmark(i64, Bookmark),
     StartupCompleted,
     SystemThemeModeChange,
     ToggleContextPage(ContextPage),
-    UpdateAccount(Account),
-    UpdateBookmark(Account, Bookmark),
     UpdateConfig(CosmicConfig),
     ViewBookmarkNotes(Bookmark),
 }

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -30,7 +30,7 @@ impl _MenuAction for MenuAction {
         match self {
             MenuAction::About => ApplicationAction::ToggleContextPage(ContextPage::About),
             MenuAction::Empty => ApplicationAction::Empty,
-            MenuAction::AddAccount => ApplicationAction::AddAccount,
+            MenuAction::AddAccount => ApplicationAction::AddAccountForm,
             MenuAction::Settings => ApplicationAction::ToggleContextPage(ContextPage::Settings),
             MenuAction::AddBookmark => ApplicationAction::AddBookmarkForm,
             MenuAction::RefreshBookmarks => ApplicationAction::StartRefreshBookmarksForAllAccounts,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -348,7 +348,7 @@ impl SqliteDatabase {
                 date_modified=$13,
                 website_title=$14,
                 website_description=$15
-            WHERE id=$16;";
+            WHERE linkding_internal_id=$16 AND user_account_id=$17;";
         sqlx::query(query)
             .bind(&new_bookmark.url)
             .bind(&new_bookmark.title)
@@ -365,7 +365,8 @@ impl SqliteDatabase {
             .bind(&new_bookmark.date_modified)
             .bind(&new_bookmark.website_title)
             .bind(&new_bookmark.website_description)
-            .bind(old_bookmark.id)
+            .bind(old_bookmark.linkding_internal_id)
+            .bind(old_bookmark.user_account_id)
             .execute(&self.conn)
             .await
             .unwrap();

--- a/src/models/account.rs
+++ b/src/models/account.rs
@@ -41,24 +41,31 @@ impl Account {
 // NOTE: (vkhitrin) we do not use these preferences as part of the application.
 //       This is a response from the API and is not used in the application.
 //       We implement a general sorting mechanism for all bookmarks.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct SearchPreferences {
     pub sort: Option<String>,
     pub shared: Option<String>,
     pub unread: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+// NOTE: (vkhitrin) we do not use most of these values as part of the application.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct LinkdingAccountApiResponse {
-    pub theme: String,
     pub bookmark_date_display: String,
-    pub web_archive_integration: String,
-    pub tag_search: String,
-    pub enable_sharing: bool,
-    pub enable_public_sharing: bool,
-    pub enable_favicons: bool,
     pub display_url: bool,
+    // NOTE: (vkhitrin) we do not check if the account enabled favicons, we check individual
+    // bookmarks if they contain favicon URL
+    pub enable_favicons: bool,
+    pub enable_public_sharing: bool,
+    pub enable_sharing: bool,
+    // NOTE: (vkhitrin) internal field to represent a potential failure
+    pub error: Option<String>,
     pub permanent_notes: bool,
     pub search_preferences: SearchPreferences,
+    // NOTE: (vkhitrin) internal field to represent a successful API call
+    pub successful: Option<bool>,
+    pub tag_search: String,
+    pub theme: String,
+    pub web_archive_integration: String,
 }

--- a/src/models/bookmarks.rs
+++ b/src/models/bookmarks.rs
@@ -50,7 +50,7 @@ impl Bookmark {
         linkding_tag_names: Vec<String>,
         linkding_date_added: Option<String>,
         linkding_date_modified: Option<String>,
-        internnal_workaround_is_owner: Option<bool>,
+        internal_workaround_is_owner: Option<bool>,
     ) -> Self {
         Self {
             id: None,
@@ -71,7 +71,7 @@ impl Bookmark {
             tag_names: linkding_tag_names,
             date_added: linkding_date_added,
             date_modified: linkding_date_modified,
-            is_owner: internnal_workaround_is_owner,
+            is_owner: internal_workaround_is_owner,
             favicon_cached: None,
         }
     }
@@ -148,8 +148,16 @@ pub struct LinkdingBookmarksApiCheckResponse {
     pub auto_tags: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CheckDetailsResponse {
-    pub bookmark: Bookmark,
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BookmarkCheckDetailsResponse {
+    pub bookmark: Option<Bookmark>,
+    pub error: Option<String>,
     pub is_new: bool,
+    pub successful: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BookmarkRemoveResponse {
+    pub error: Option<String>,
+    pub successful: bool,
 }

--- a/src/pages/accounts.rs
+++ b/src/pages/accounts.rs
@@ -285,13 +285,13 @@ impl PageAccountsView {
         match message {
             AccountsAction::AddAccount => {
                 commands.push(Task::perform(async {}, |()| {
-                    cosmic::Action::App(ApplicationAction::AddAccount)
+                    cosmic::Action::App(ApplicationAction::AddAccountForm)
                 }));
             }
             AccountsAction::EditAccount(account) => {
                 self.account_placeholder = Some(account.clone());
                 commands.push(Task::perform(async {}, move |()| {
-                    cosmic::Action::App(ApplicationAction::EditAccount(account.clone()))
+                    cosmic::Action::App(ApplicationAction::EditAccountForm(account.clone()))
                 }));
             }
             AccountsAction::DeleteAccount(account) => {
@@ -352,8 +352,7 @@ pub fn add_account<'a>(account: Account) -> Element<'a, ApplicationAction> {
         .spacing(10)
         .label(fl!("enabled"));
     let buttons_widget_container = widget::container(
-        widget::button::standard(fl!("save"))
-            .on_press(ApplicationAction::CompleteAddAccount(account)),
+        widget::button::standard(fl!("save")).on_press(ApplicationAction::StartAddAccount(account)),
     )
     .width(Length::Fill)
     .align_x(Alignment::Center);
@@ -493,7 +492,8 @@ pub fn edit_account<'a>(account: Account) -> Element<'a, ApplicationAction> {
         .padding(10)
     };
     let buttons_widget_container = widget::container(
-        widget::button::standard(fl!("save")).on_press(ApplicationAction::UpdateAccount(account)),
+        widget::button::standard(fl!("save"))
+            .on_press(ApplicationAction::StartEditAccount(account)),
     )
     .width(Length::Fill)
     .align_x(Alignment::Center);

--- a/src/pages/bookmarks.rs
+++ b/src/pages/bookmarks.rs
@@ -389,7 +389,7 @@ impl PageBookmarksView {
             BookmarksAction::EditBookmark(account_id, bookmark) => {
                 self.bookmark_placeholder = Some(bookmark.clone());
                 commands.push(Task::perform(async {}, move |()| {
-                    cosmic::Action::App(ApplicationAction::EditBookmark(
+                    cosmic::Action::App(ApplicationAction::EditBookmarkForm(
                         account_id,
                         bookmark.clone(),
                     ))
@@ -511,7 +511,7 @@ where
         });
     let buttons_widget_container =
         widget::container(widget::button::standard(fl!("save")).on_press(
-            ApplicationAction::AddBookmark(accounts[selected_account_index].clone(), bookmark),
+            ApplicationAction::StartAddBookmark(accounts[selected_account_index].clone(), bookmark),
         ))
         .width(Length::Fill)
         .align_x(Alignment::Center);
@@ -679,12 +679,12 @@ where
         } else {
             fl!("shared-disabled")
         });
-    let buttons_widget_container = widget::container(
-        widget::button::standard(fl!("save"))
-            .on_press(ApplicationAction::UpdateBookmark(account.clone(), bookmark)),
-    )
-    .width(Length::Fill)
-    .align_x(Alignment::Center);
+    let buttons_widget_container =
+        widget::container(widget::button::standard(fl!("save")).on_press(
+            ApplicationAction::StartEditBookmark(account.clone(), bookmark),
+        ))
+        .width(Length::Fill)
+        .align_x(Alignment::Center);
 
     widget::column()
         .spacing(space_xxs)


### PR DESCRIPTION
Delegate HTTP calls to a separate thread to avoid blocking UI (resolves #60).

Improve internal logging (resolves #88).

Bump cargo dependencies.
