### PR TITLE
chore: Prepare For v2025.5.1 Release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.20"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "jobserver",
  "libc",
@@ -1071,7 +1071,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
+source = "git+https://github.com/pop-os/libcosmic#7151638f519941d8439ad0ee05723c39ed561941"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1093,7 +1093,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
+source = "git+https://github.com/pop-os/libcosmic#7151638f519941d8439ad0ee05723c39ed561941"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1159,7 +1159,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
+source = "git+https://github.com/pop-os/libcosmic#7151638f519941d8439ad0ee05723c39ed561941"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "cosmicding"
-version = "2025.5.0"
+version = "2025.5.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2658,7 +2658,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
+source = "git+https://github.com/pop-os/libcosmic#7151638f519941d8439ad0ee05723c39ed561941"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
+source = "git+https://github.com/pop-os/libcosmic#7151638f519941d8439ad0ee05723c39ed561941"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -2685,7 +2685,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
+source = "git+https://github.com/pop-os/libcosmic#7151638f519941d8439ad0ee05723c39ed561941"
 dependencies = [
  "bitflags 2.9.0",
  "bytes",
@@ -2710,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
+source = "git+https://github.com/pop-os/libcosmic#7151638f519941d8439ad0ee05723c39ed561941"
 dependencies = [
  "futures",
  "iced_core",
@@ -2736,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
+source = "git+https://github.com/pop-os/libcosmic#7151638f519941d8439ad0ee05723c39ed561941"
 dependencies = [
  "bitflags 2.9.0",
  "bytemuck",
@@ -2758,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
+source = "git+https://github.com/pop-os/libcosmic#7151638f519941d8439ad0ee05723c39ed561941"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2770,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
+source = "git+https://github.com/pop-os/libcosmic#7151638f519941d8439ad0ee05723c39ed561941"
 dependencies = [
  "bytes",
  "cosmic-client-toolkit",
@@ -2786,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
+source = "git+https://github.com/pop-os/libcosmic#7151638f519941d8439ad0ee05723c39ed561941"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2802,7 +2802,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
+source = "git+https://github.com/pop-os/libcosmic#7151638f519941d8439ad0ee05723c39ed561941"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.9.0",
@@ -2833,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
+source = "git+https://github.com/pop-os/libcosmic#7151638f519941d8439ad0ee05723c39ed561941"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -2852,7 +2852,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
+source = "git+https://github.com/pop-os/libcosmic#7151638f519941d8439ad0ee05723c39ed561941"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -3200,9 +3200,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a064218214dc6a10fbae5ec5fa888d80c45d611aba169222fc272072bf7aef6"
+checksum = "d07d8d955d798e7a4d6f9c58cd1f1916e790b42b092758a9ef6e16fef9f1b3fd"
 dependencies = [
  "jiff-static",
  "log",
@@ -3213,9 +3213,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
+checksum = "f244cfe006d98d26f859c7abd1318d85327e1882dc9cef80f62daeeb0adcf300"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3363,7 +3363,7 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#e838616813470aa6a108ede07ab8e6050b68a5a6"
+source = "git+https://github.com/pop-os/libcosmic#7151638f519941d8439ad0ee05723c39ed561941"
 dependencies = [
  "apply",
  "ashpd 0.9.2",
@@ -3396,7 +3396,7 @@ dependencies = [
  "palette",
  "rfd",
  "ron",
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "serde",
  "shlex",
  "slotmap",
@@ -4211,9 +4211,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",
@@ -5069,9 +5069,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
@@ -5878,7 +5878,7 @@ dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -6136,7 +6136,7 @@ checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow 0.7.7",
+ "winnow 0.7.9",
 ]
 
 [[package]]
@@ -7379,9 +7379,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
+checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmicding"
-version = "2025.5.0"
+version = "2025.5.1"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ sudo just install
 ### Local Install (flatpak)
 
 ```shell
+# Ensure flathub remote is added to user
+flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 flatpak-builder --force-clean \
                 --sandbox \
                 --user \

--- a/res/flatpak/cargo-sources.json
+++ b/res/flatpak/cargo-sources.json
@@ -26,8 +26,8 @@
     {
         "type": "git",
         "url": "https://github.com/pop-os/libcosmic",
-        "commit": "e838616813470aa6a108ede07ab8e6050b68a5a6",
-        "dest": "flatpak-cargo/git/libcosmic-e838616"
+        "commit": "7151638f519941d8439ad0ee05723c39ed561941",
+        "dest": "flatpak-cargo/git/libcosmic-7151638"
     },
     {
         "type": "git",
@@ -1160,14 +1160,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cc/cc-1.2.20.crate",
-        "sha256": "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a",
-        "dest": "cargo/vendor/cc-1.2.20"
+        "url": "https://static.crates.io/crates/cc/cc-1.2.21.crate",
+        "sha256": "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0",
+        "dest": "cargo/vendor/cc-1.2.21"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a\", \"files\": {}}",
-        "dest": "cargo/vendor/cc-1.2.20",
+        "contents": "{\"package\": \"8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0\", \"files\": {}}",
+        "dest": "cargo/vendor/cc-1.2.21",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1544,7 +1544,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-e838616/cosmic-config\" \"cargo/vendor/cosmic-config\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-7151638/cosmic-config\" \"cargo/vendor/cosmic-config\""
         ]
     },
     {
@@ -1562,7 +1562,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-e838616/cosmic-config-derive\" \"cargo/vendor/cosmic-config-derive\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-7151638/cosmic-config-derive\" \"cargo/vendor/cosmic-config-derive\""
         ]
     },
     {
@@ -1652,7 +1652,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-e838616/cosmic-theme\" \"cargo/vendor/cosmic-theme\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-7151638/cosmic-theme\" \"cargo/vendor/cosmic-theme\""
         ]
     },
     {
@@ -3591,7 +3591,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-e838616/iced\" \"cargo/vendor/iced\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-7151638/iced\" \"cargo/vendor/iced\""
         ]
     },
     {
@@ -3609,7 +3609,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-e838616/iced/accessibility\" \"cargo/vendor/iced_accessibility\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-7151638/iced/accessibility\" \"cargo/vendor/iced_accessibility\""
         ]
     },
     {
@@ -3627,7 +3627,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-e838616/iced/core\" \"cargo/vendor/iced_core\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-7151638/iced/core\" \"cargo/vendor/iced_core\""
         ]
     },
     {
@@ -3645,7 +3645,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-e838616/iced/futures\" \"cargo/vendor/iced_futures\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-7151638/iced/futures\" \"cargo/vendor/iced_futures\""
         ]
     },
     {
@@ -3681,7 +3681,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-e838616/iced/graphics\" \"cargo/vendor/iced_graphics\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-7151638/iced/graphics\" \"cargo/vendor/iced_graphics\""
         ]
     },
     {
@@ -3699,7 +3699,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-e838616/iced/renderer\" \"cargo/vendor/iced_renderer\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-7151638/iced/renderer\" \"cargo/vendor/iced_renderer\""
         ]
     },
     {
@@ -3717,7 +3717,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-e838616/iced/runtime\" \"cargo/vendor/iced_runtime\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-7151638/iced/runtime\" \"cargo/vendor/iced_runtime\""
         ]
     },
     {
@@ -3735,7 +3735,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-e838616/iced/tiny_skia\" \"cargo/vendor/iced_tiny_skia\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-7151638/iced/tiny_skia\" \"cargo/vendor/iced_tiny_skia\""
         ]
     },
     {
@@ -3753,7 +3753,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-e838616/iced/wgpu\" \"cargo/vendor/iced_wgpu\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-7151638/iced/wgpu\" \"cargo/vendor/iced_wgpu\""
         ]
     },
     {
@@ -3771,7 +3771,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-e838616/iced/widget\" \"cargo/vendor/iced_widget\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-7151638/iced/widget\" \"cargo/vendor/iced_widget\""
         ]
     },
     {
@@ -3789,7 +3789,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-e838616/iced/winit\" \"cargo/vendor/iced_winit\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-7151638/iced/winit\" \"cargo/vendor/iced_winit\""
         ]
     },
     {
@@ -4223,27 +4223,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/jiff/jiff-0.2.10.crate",
-        "sha256": "5a064218214dc6a10fbae5ec5fa888d80c45d611aba169222fc272072bf7aef6",
-        "dest": "cargo/vendor/jiff-0.2.10"
+        "url": "https://static.crates.io/crates/jiff/jiff-0.2.12.crate",
+        "sha256": "d07d8d955d798e7a4d6f9c58cd1f1916e790b42b092758a9ef6e16fef9f1b3fd",
+        "dest": "cargo/vendor/jiff-0.2.12"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5a064218214dc6a10fbae5ec5fa888d80c45d611aba169222fc272072bf7aef6\", \"files\": {}}",
-        "dest": "cargo/vendor/jiff-0.2.10",
+        "contents": "{\"package\": \"d07d8d955d798e7a4d6f9c58cd1f1916e790b42b092758a9ef6e16fef9f1b3fd\", \"files\": {}}",
+        "dest": "cargo/vendor/jiff-0.2.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/jiff-static/jiff-static-0.2.10.crate",
-        "sha256": "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254",
-        "dest": "cargo/vendor/jiff-static-0.2.10"
+        "url": "https://static.crates.io/crates/jiff-static/jiff-static-0.2.12.crate",
+        "sha256": "f244cfe006d98d26f859c7abd1318d85327e1882dc9cef80f62daeeb0adcf300",
+        "dest": "cargo/vendor/jiff-static-0.2.12"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254\", \"files\": {}}",
-        "dest": "cargo/vendor/jiff-static-0.2.10",
+        "contents": "{\"package\": \"f244cfe006d98d26f859c7abd1318d85327e1882dc9cef80f62daeeb0adcf300\", \"files\": {}}",
+        "dest": "cargo/vendor/jiff-static-0.2.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4444,7 +4444,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-e838616/.\" \"cargo/vendor/libcosmic\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/libcosmic-7151638/.\" \"cargo/vendor/libcosmic\""
         ]
     },
     {
@@ -5481,14 +5481,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/openssl-sys/openssl-sys-0.9.107.crate",
-        "sha256": "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07",
-        "dest": "cargo/vendor/openssl-sys-0.9.107"
+        "url": "https://static.crates.io/crates/openssl-sys/openssl-sys-0.9.108.crate",
+        "sha256": "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847",
+        "dest": "cargo/vendor/openssl-sys-0.9.108"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07\", \"files\": {}}",
-        "dest": "cargo/vendor/openssl-sys-0.9.107",
+        "contents": "{\"package\": \"e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847\", \"files\": {}}",
+        "dest": "cargo/vendor/openssl-sys-0.9.108",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6573,14 +6573,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustix/rustix-1.0.5.crate",
-        "sha256": "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf",
-        "dest": "cargo/vendor/rustix-1.0.5"
+        "url": "https://static.crates.io/crates/rustix/rustix-1.0.7.crate",
+        "sha256": "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266",
+        "dest": "cargo/vendor/rustix-1.0.7"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf\", \"files\": {}}",
-        "dest": "cargo/vendor/rustix-1.0.5",
+        "contents": "{\"package\": \"c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266\", \"files\": {}}",
+        "dest": "cargo/vendor/rustix-1.0.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -9484,14 +9484,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/winnow/winnow-0.7.7.crate",
-        "sha256": "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5",
-        "dest": "cargo/vendor/winnow-0.7.7"
+        "url": "https://static.crates.io/crates/winnow/winnow-0.7.9.crate",
+        "sha256": "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3",
+        "dest": "cargo/vendor/winnow-0.7.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5\", \"files\": {}}",
-        "dest": "cargo/vendor/winnow-0.7.7",
+        "contents": "{\"package\": \"d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3\", \"files\": {}}",
+        "dest": "cargo/vendor/winnow-0.7.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/res/flatpak/com.vkhitrin.cosmicding.metainfo.xml
+++ b/res/flatpak/com.vkhitrin.cosmicding.metainfo.xml
@@ -35,6 +35,18 @@
         https://raw.githubusercontent.com/vkhitrin/cosmicding/refs/heads/main/res/icons/hicolor/scalable/apps/com.vkhitrin.cosmicding.svg</icon>
     <launchable type="desktop-id">com.vkhitrin.cosmicding.desktop</launchable>
     <releases>
+        <release version="2025.5.1" date="2025-05-03">
+            <description>
+                <p>New Features:</p>
+                <ul>
+                    <li>Focus on search field using a keybinding (CTRL+F).</li>
+                </ul>
+                <p>Fixes:</p>
+                <ul>
+                    <li>Reduce calls to remote instance when updating accounts.</li>
+                </ul>
+            </description>
+        </release>
         <release version="2025.5.0" date="2025-05-01">
             <description>
                 <p>

--- a/res/flatpak/com.vkhitrin.cosmicding.yaml
+++ b/res/flatpak/com.vkhitrin.cosmicding.yaml
@@ -32,4 +32,4 @@ modules:
       - cargo-sources.json
       - type: git
         url: https://github.com/vkhitrin/cosmicding.git
-        tag: v2025.5.0
+        tag: v2025.5.1


### PR DESCRIPTION
Update cargo dependencies.

Update flatpak.
