### PR TITLE
fix: Avoid Endless Favicon Fetching

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -491,20 +491,20 @@ pub async fn edit_bookmark(
             }
             Err(_e) => {
                 log::error!("Failed to parse response");
-                Err(Box::new(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    fl!("failed-to-parse-response"),
-                )))
+                Err(Box::new(std::io::Error::other(fl!(
+                    "failed-to-parse-response"
+                ))))
             }
         },
         status => {
             let http_rc = status.to_string();
             let http_err = response.text().await.unwrap();
             log::error!("HTTP Error: {http_rc} {http_err}");
-            Err(Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                fl!("http-error", http_rc = http_rc, http_err = http_err),
-            )))
+            Err(Box::new(std::io::Error::other(fl!(
+                "http-error",
+                http_rc = http_rc,
+                http_err = http_err
+            ))))
         }
     }
 }
@@ -556,22 +556,15 @@ pub async fn check_account_on_instance(
     match response.status() {
         StatusCode::OK => match response.json::<LinkdingAccountApiResponse>().await {
             Ok(value) => Ok(value),
-            Err(_e) => Err(Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                fl!("failed-to-find-linkding-api-endpoint"),
-            ))),
+            Err(_e) => Err(Box::new(std::io::Error::other(fl!(
+                "failed-to-find-linkding-api-endpoint"
+            )))),
         },
-        StatusCode::UNAUTHORIZED => Err(Box::new(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            fl!("invalid-api-token"),
-        ))),
-        _ => Err(Box::new(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            fl!(
-                "unexpected-http-return-code",
-                http_rc = response.status().to_string()
-            ),
-        ))),
+        StatusCode::UNAUTHORIZED => Err(Box::new(std::io::Error::other(fl!("invalid-api-token")))),
+        _ => Err(Box::new(std::io::Error::other(fl!(
+            "unexpected-http-return-code",
+            http_rc = response.status().to_string()
+        )))),
     }
 }
 
@@ -603,22 +596,15 @@ pub async fn check_bookmark_on_instance(
     match response.status() {
         StatusCode::OK => match response.json::<LinkdingBookmarksApiCheckResponse>().await {
             Ok(value) => Ok(value),
-            Err(_e) => Err(Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                fl!("failed-to-find-linkding-api-endpoint"),
-            ))),
+            Err(_e) => Err(Box::new(std::io::Error::other(fl!(
+                "failed-to-find-linkding-api-endpoint"
+            )))),
         },
-        StatusCode::UNAUTHORIZED => Err(Box::new(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            fl!("invalid-api-token"),
-        ))),
-        _ => Err(Box::new(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            fl!(
-                "unexpected-http-return-code",
-                http_rc = response.status().to_string()
-            ),
-        ))),
+        StatusCode::UNAUTHORIZED => Err(Box::new(std::io::Error::other(fl!("invalid-api-token")))),
+        _ => Err(Box::new(std::io::Error::other(fl!(
+            "unexpected-http-return-code",
+            http_rc = response.status().to_string()
+        )))),
     }
 }
 

--- a/src/models/favicon_cache.rs
+++ b/src/models/favicon_cache.rs
@@ -1,17 +1,18 @@
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow, Eq, PartialEq)]
+#[allow(clippy::struct_field_names)]
 pub struct Favicon {
-    pub url: String,
-    pub data: Vec<u8>,
+    pub favicon_url: String,
+    pub favicon_data: Vec<u8>,
     pub last_sync_timestamp: i64,
 }
 impl Favicon {
     #[allow(clippy::too_many_arguments)]
     pub fn new(favicon_url: String, favicon_data: Vec<u8>, last_sync_timestamp: i64) -> Self {
         Self {
-            url: favicon_url,
-            data: favicon_data,
+            favicon_url,
+            favicon_data,
             last_sync_timestamp,
         }
     }

--- a/src/pages/bookmarks.rs
+++ b/src/pages/bookmarks.rs
@@ -74,8 +74,8 @@ impl PageBookmarksView {
                 let favicon_data = bookmark
                     .favicon_cached
                     .as_ref()
-                    .filter(|cached| !cached.data.is_empty())
-                    .map(|cached| cached.data.clone());
+                    .filter(|cached| !cached.favicon_data.is_empty())
+                    .map(|cached| cached.favicon_data.clone());
                 let favicon: widget::image::Handle = if let Some(data) = favicon_data {
                     widget::image::Handle::from_bytes(data)
                 } else {


### PR DESCRIPTION
Will not attempt to fetch favicons endlessly from remote.
Failed favicons will be marked as stale, and will be attempted to be
refetched every hour.
Populated favicons will be marked as stale, and will be attempted to be
refetched once a day.

Resolves #112.
