### PR TITLE
Fix & improve metainfo

### DIFF
--- a/res/flatpak/com.vkhitrin.cosmicding.metainfo.xml
+++ b/res/flatpak/com.vkhitrin.cosmicding.metainfo.xml
@@ -25,11 +25,8 @@
         <ul>
             <li>Store bookmarks locally</li>
             <li xml:lang="cs">Lokální ukládání záložek</li>
-            <li>Support remote bookmarks providers:</li>
-            <li xml:lang="cs">Podpora poskytovatelů vzdálených záložek:</li>
-            <ul>
-                <li>linkding</li>
-            </ul>
+            <li>Support remote bookmarks providers: 'linkding'</li>
+            <li xml:lang="cs">Podpora poskytovatelů vzdálených záložek: 'linkding'</li>
             <li>Aggregate bookmarks from multiple providers.</li>
             <li xml:lang="cs">Kombinace záložek od více poskytovatelů.</li>
             <li>Add/Edit/Remove bookmarks.</li>

--- a/res/flatpak/com.vkhitrin.cosmicding.metainfo.xml
+++ b/res/flatpak/com.vkhitrin.cosmicding.metainfo.xml
@@ -30,11 +30,11 @@
             <li>Aggregate bookmarks from multiple providers</li>
             <li xml:lang="cs">Kombinace záložek od více poskytovatelů</li>
             <li>Add/Edit/Remove bookmarks</li>
-            <li xml:lang="cs">Přidávání/Upravování/Odstraňování záložek</li>
+            <li xml:lang="cs">Přidávání, upravování a odstraňování záložek</li>
             <li>Search bookmarks based on title, URL, tags, description, and notes</li>
             <li xml:lang="cs">Vyhledávání záložek podle názvu, URL, štítků, popisu a poznámek</li>
             <li>Import/Export bookmarks</li>
-            <li xml:lang="cs">Import/Export záložek</li>
+            <li xml:lang="cs">Import a export záložek</li>
         </ul>
     </description>
     <branding>

--- a/res/flatpak/com.vkhitrin.cosmicding.metainfo.xml
+++ b/res/flatpak/com.vkhitrin.cosmicding.metainfo.xml
@@ -25,16 +25,16 @@
         <ul>
             <li>Store bookmarks locally</li>
             <li xml:lang="cs">Lokální ukládání záložek</li>
-            <li>Support remote bookmarks providers: 'linkding'</li>
+            <li>Support for remote bookmarks providers: 'linkding'</li>
             <li xml:lang="cs">Podpora poskytovatelů vzdálených záložek: 'linkding'</li>
-            <li>Aggregate bookmarks from multiple providers.</li>
-            <li xml:lang="cs">Kombinace záložek od více poskytovatelů.</li>
-            <li>Add/Edit/Remove bookmarks.</li>
-            <li xml:lang="cs">Přidávání/Upravování/Odstraňování záložek.</li>
-            <li>Search bookmarks based on title, URL, tags, description, and notes.</li>
-            <li xml:lang="cs">Vyhledávání záložek podle názvu, URL, štítků, popisu a poznámek.</li>
-            <li>Import/Export bookmarks.</li>
-            <li xml:lang="cs">Import/Export záložek.</li>
+            <li>Aggregate bookmarks from multiple providers</li>
+            <li xml:lang="cs">Kombinace záložek od více poskytovatelů</li>
+            <li>Add/Edit/Remove bookmarks</li>
+            <li xml:lang="cs">Přidávání/Upravování/Odstraňování záložek</li>
+            <li>Search bookmarks based on title, URL, tags, description, and notes</li>
+            <li xml:lang="cs">Vyhledávání záložek podle názvu, URL, štítků, popisu a poznámek</li>
+            <li>Import/Export bookmarks</li>
+            <li xml:lang="cs">Import/Export záložek</li>
         </ul>
     </description>
     <branding>


### PR DESCRIPTION
Hello again!

I noticed that on Flathub and in app stores, the description falls back to English instead of being localized to Czech. There was nothing wrong with the translation, so I checked the validation of the metainfo file and the commit history.

#### Validation (before fix)
```sh
appstreamcli validate --pedantic com.vkhitrin.cosmicding.metainfo.xml

I: com.vkhitrin.cosmicding:21: description-first-para-too-short
     A client to manage your bookmarks.
E: com.vkhitrin.cosmicding:30: description-enum-item-invalid ul
I: com.vkhitrin.cosmicding:130: relation-control-in-requires
I: com.vkhitrin.cosmicding:131: relation-control-in-requires

✘ Validation failed: errors: 1, infos: 3
```

The validator complains that there is an invalid `ul` element inside the description. You removed that in commit c446b8e, but then your changes got overwritten later in 5ed5dd3

I fixed the metainfo validation (based on your commit c446b8e). I'm not sure whether this will fix the localization problem, but it should as there is absolutely no other reason

#### Validation (after fix)
```sh
appstreamcli validate --pedantic com.vkhitrin.cosmicding.metainfo.xml

I: com.vkhitrin.cosmicding:21: description-first-para-too-short
     A client to manage your bookmarks.
I: com.vkhitrin.cosmicding:128: relation-control-in-requires
I: com.vkhitrin.cosmicding:129: relation-control-in-requires

✔ Validation was successful: infos: 3
```

### Additionally
- I improved style by removing unnecessary dots from the listed functions under description and editing the "Support remote bookmarks providers" sentence to sound more natural
- I improved Czech translation of the metainfo